### PR TITLE
[W 5.11][CS2113-AY1819S1-F10-3]Ong Wee Keong

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -59,7 +59,8 @@ items with `...` after them can have multiple instances. Order of parameters are
 Put a `p` before the phone / email / address prefixes to mark it as `private`. `private` details can only
 be seen using the `viewall` command.
 
-Persons with duplicate primary key identity fields (Same name AND same phone number/email, or even different name with same phone number AND email) will not be allowed.
+Persons with duplicate primary key identity fields (Same name AND same phone number/email, or even different
+name with same phone number AND email) will not be allowed.
 
 Persons can have any number of tags (including 0).
 ****

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -59,6 +59,8 @@ items with `...` after them can have multiple instances. Order of parameters are
 Put a `p` before the phone / email / address prefixes to mark it as `private`. `private` details can only
 be seen using the `viewall` command.
 
+Persons with duplicate primary key identity fields (Same name AND same phone number/email, or even different name with same phone number AND email) will not be allowed.
+
 Persons can have any number of tags (including 0).
 ****
 

--- a/src/seedu/addressbook/data/person/ReadOnlyPerson.java
+++ b/src/seedu/addressbook/data/person/ReadOnlyPerson.java
@@ -28,11 +28,11 @@ public interface ReadOnlyPerson {
     default boolean isSamePerson(ReadOnlyPerson other) {
         return (other == this)
                 || (other != null
-                    && (other.getName().equals(this.getName())
+                    && other.getPhone().equals(this.getPhone())
+                    && other.getEmail().equals(this.getEmail())
+                    || (other.getName().equals(this.getName())
                     && (other.getPhone().equals(this.getPhone())
-                    || other.getEmail().equals(this.getEmail())))
-                    || other.getPhone().equals(this.getPhone())
-                    && other.getEmail().equals(this.getEmail()));
+                    || other.getEmail().equals(this.getEmail()))));
     }
 
     /**

--- a/src/seedu/addressbook/data/person/ReadOnlyPerson.java
+++ b/src/seedu/addressbook/data/person/ReadOnlyPerson.java
@@ -22,13 +22,17 @@ public interface ReadOnlyPerson {
     Set<Tag> getTags();
 
     /**
-     * Returns true if both persons have the same identity fields (name and telephone).
+     * Returns true if both persons have the same identity fields (name and telephone and/or email).
+     * Will also return true if a different person has the same telephone and email.
      */
     default boolean isSamePerson(ReadOnlyPerson other) {
         return (other == this)
                 || (other != null
-                    && other.getName().equals(this.getName())
-                    && other.getPhone().equals(this.getPhone()));
+                    && (other.getName().equals(this.getName())
+                    && (other.getPhone().equals(this.getPhone())
+                    || other.getEmail().equals(this.getEmail())))
+                    || other.getPhone().equals(this.getPhone())
+                    && other.getEmail().equals(this.getEmail()));
     }
 
     /**

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -86,11 +86,6 @@ public class Parser {
             case FindCommand.COMMAND_WORD:
                 return prepareFind(arguments);
 
-            case TotalCommand.COMMAND_WORD:
-                return new TotalCommand();
-
-            case ExitCommand.COMMAND_WORD:
-                return new ExitCommand();
 
             case ListCommand.COMMAND_WORD:
                 return new ListCommand();


### PR DESCRIPTION
Added restrictions to the 'add' command:
1. Persons with same name AND phone number/email (or both) cannot be added to address book.
2. Persons with different name but same phone number AND email cannot be added.

Removed duplicate labels in parser.